### PR TITLE
Background Soundtrack

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+bootcamp

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/app/src/main/res/raw/success_fanfare_trumpets.mp3" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/app/src/main/res/raw/sweep.mp3" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/app/src/main/res/raw/waterfall_short.mp3" charset="UTF-8" />
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Bootcamp"
         tools:targetApi="31">
+        <service
+            android:name=".BackgroundMusicService"
+            android:enabled="true"
+            android:exported="true"></service>
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
@@ -21,6 +26,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".GreetingActivity" />
+        <activity android:name="BackgroundMusicExampleActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicExampleActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicExampleActivity.kt
@@ -1,33 +1,56 @@
 package com.github.freeman.bootcamp
 
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.os.Bundle
+import android.os.IBinder
+import android.view.View
 import android.widget.Button
+import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 
 class BackgroundMusicExampleActivity : AppCompatActivity() {
 
-//    val startService: Button
-//    val stopService: Button
     private lateinit var i: Intent
+//    private var isRunning = false;
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_background_music_example)
         val startService = findViewById<Button>(R.id.buttonStartService)
         val stopService = findViewById<Button>(R.id.buttonStopService)
+//        val conn = BackgroundMusicServiceConnection()
 
         startService.setOnClickListener {
             i = Intent(this, BackgroundMusicService::class.java)
+//            bindService(i, conn, Context.BIND_AUTO_CREATE)
             startService(i)
         }
 
         stopService.setOnClickListener {
             stopService(i)
+//            unbindService(conn)
+//            isRunning = false
         }
-
     }
 
+//    inner class BackgroundMusicServiceConnection : ServiceConnection {
+//        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+//            val binder: BackgroundMusicService.MusicBinder = service as BackgroundMusicService.MusicBinder
+//            backgroundMusicService = binder.service
+//            isRunning = true
+//        }
+//
+//        override fun onServiceDisconnected(name: ComponentName?) {
+//            isRunning = false
+//        }
+//
+//    }
 
+    fun back(view: View) {
+        this.finish()
+    }
 }

--- a/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicExampleActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicExampleActivity.kt
@@ -15,40 +15,22 @@ import androidx.appcompat.app.AppCompatActivity
 class BackgroundMusicExampleActivity : AppCompatActivity() {
 
     private lateinit var i: Intent
-//    private var isRunning = false;
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_background_music_example)
         val startService = findViewById<Button>(R.id.buttonStartService)
         val stopService = findViewById<Button>(R.id.buttonStopService)
-//        val conn = BackgroundMusicServiceConnection()
 
         startService.setOnClickListener {
             i = Intent(this, BackgroundMusicService::class.java)
-//            bindService(i, conn, Context.BIND_AUTO_CREATE)
             startService(i)
         }
 
         stopService.setOnClickListener {
             stopService(i)
-//            unbindService(conn)
-//            isRunning = false
         }
     }
-
-//    inner class BackgroundMusicServiceConnection : ServiceConnection {
-//        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
-//            val binder: BackgroundMusicService.MusicBinder = service as BackgroundMusicService.MusicBinder
-//            backgroundMusicService = binder.service
-//            isRunning = true
-//        }
-//
-//        override fun onServiceDisconnected(name: ComponentName?) {
-//            isRunning = false
-//        }
-//
-//    }
 
     fun back(view: View) {
         this.finish()

--- a/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicExampleActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicExampleActivity.kt
@@ -1,0 +1,33 @@
+package com.github.freeman.bootcamp
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+
+class BackgroundMusicExampleActivity : AppCompatActivity() {
+
+//    val startService: Button
+//    val stopService: Button
+    private lateinit var i: Intent
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_background_music_example)
+        val startService = findViewById<Button>(R.id.buttonStartService)
+        val stopService = findViewById<Button>(R.id.buttonStopService)
+
+        startService.setOnClickListener {
+            i = Intent(this, BackgroundMusicService::class.java)
+            startService(i)
+        }
+
+        stopService.setOnClickListener {
+            stopService(i)
+        }
+
+    }
+
+
+}

--- a/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicService.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicService.kt
@@ -11,11 +11,9 @@ class BackgroundMusicService : Service() {
 
     private val tag = "BackgroundMusicServiceLog"
     private lateinit var mediaPlayer: MediaPlayer
-//    private lateinit var binder: MusicBinder
 
     override fun onBind(intent: Intent): IBinder {
         TODO("Return the communication channel to the service.")
-//        return binder;
     }
 
     override fun onCreate() {
@@ -36,9 +34,4 @@ class BackgroundMusicService : Service() {
         Log.i(tag, "Executing onDestroy")
         mediaPlayer.stop()
     }
-
-//    inner class MusicBinder : Binder() {
-//        val service: BackgroundMusicService
-//            get() = this@BackgroundMusicService
-//    }
 }

--- a/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicService.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicService.kt
@@ -1,0 +1,36 @@
+package com.github.freeman.bootcamp
+
+import android.app.Service
+import android.content.Intent
+import android.media.MediaPlayer
+import android.os.IBinder
+import android.provider.Settings
+import android.util.Log
+
+class BackgroundMusicService : Service() {
+
+    private val tag = "BackgroundMusicServiceLog"
+    private lateinit var mediaPlayer: MediaPlayer
+
+    override fun onBind(intent: Intent): IBinder {
+        TODO("Return the communication channel to the service.")
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.i(tag, "Executing onCreate")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(tag, "Executing onStartCommand")
+        mediaPlayer = MediaPlayer.create(applicationContext, R.raw.waterfall)
+        mediaPlayer.start()
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i(tag, "Executing onDestroy")
+        mediaPlayer.stop()
+    }
+}

--- a/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicService.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/BackgroundMusicService.kt
@@ -3,17 +3,19 @@ package com.github.freeman.bootcamp
 import android.app.Service
 import android.content.Intent
 import android.media.MediaPlayer
+import android.os.Binder
 import android.os.IBinder
-import android.provider.Settings
 import android.util.Log
 
 class BackgroundMusicService : Service() {
 
     private val tag = "BackgroundMusicServiceLog"
     private lateinit var mediaPlayer: MediaPlayer
+//    private lateinit var binder: MusicBinder
 
     override fun onBind(intent: Intent): IBinder {
         TODO("Return the communication channel to the service.")
+//        return binder;
     }
 
     override fun onCreate() {
@@ -24,6 +26,7 @@ class BackgroundMusicService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.i(tag, "Executing onStartCommand")
         mediaPlayer = MediaPlayer.create(applicationContext, R.raw.waterfall)
+        mediaPlayer.isLooping = true;
         mediaPlayer.start()
         return super.onStartCommand(intent, flags, startId)
     }
@@ -33,4 +36,9 @@ class BackgroundMusicService : Service() {
         Log.i(tag, "Executing onDestroy")
         mediaPlayer.stop()
     }
+
+//    inner class MusicBinder : Binder() {
+//        val service: BackgroundMusicService
+//            get() = this@BackgroundMusicService
+//    }
 }

--- a/app/src/main/java/com/github/freeman/bootcamp/MainActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/MainActivity.kt
@@ -7,9 +7,12 @@ import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        val i = Intent(this, BackgroundMusicService::class.java)
+        startService(i)
     }
 
     fun greet(view: View) {

--- a/app/src/main/java/com/github/freeman/bootcamp/MainActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/MainActivity.kt
@@ -18,4 +18,10 @@ class MainActivity : AppCompatActivity() {
         myIntent.putExtra("name", name) //Optional parameters
         startActivity(myIntent)
     }
+
+    fun testBackgroundMusic(view: View) {
+        val myIntent = Intent(this, BackgroundMusicExampleActivity::class.java)
+        startActivity(myIntent)
+    }
+
 }

--- a/app/src/main/res/layout/activity_background_music_example.xml
+++ b/app/src/main/res/layout/activity_background_music_example.xml
@@ -26,4 +26,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonStartService" />
+
+    <Button
+        android:id="@+id/BackMusic"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="228dp"
+        android:onClick="back"
+        android:text="Back"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_background_music_example.xml
+++ b/app/src/main/res/layout/activity_background_music_example.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/buttonStartService"
+        android:layout_width="289dp"
+        android:layout_height="58dp"
+        android:layout_marginTop="116dp"
+        android:text="Start Service"
+        android:textSize="30dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/buttonStopService"
+        android:layout_width="289dp"
+        android:layout_height="59dp"
+        android:layout_marginTop="116dp"
+        android:text="Stop Service"
+        android:textSize="30dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonStartService" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,4 +29,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/mainName" />
 
+    <Button
+        android:id="@+id/testBackgroundMusicButton"
+        android:layout_width="234dp"
+        android:layout_height="51dp"
+        android:layout_marginTop="68dp"
+        android:onClick="testBackgroundMusic"
+        android:text="Test Background Music"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/mainSubmitButton"
+        app:layout_constraintVertical_bias="0.369" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'com.android.library' version '7.4.1' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }


### PR DESCRIPTION
Currently the app should start with the soundtrack playing in the background, which continues even when switching activities and loops once it has finished.
A button on MainActivity leading to a separate activity allowing to start and stop a soundtrack background service has been added for testing purposes and might be removed in the future.