### PR TITLE
Anonymous account

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -253,6 +253,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="1821248570">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="39V4C19703010730" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1822292161">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -260,6 +260,7 @@
                 <map>
                   <entry key="39V4C19703010730" value="120" />
                   <entry key="Duration" value="90" />
+                  <entry key="HUAWEI&#10; POT-LX1" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
@@ -2,12 +2,15 @@ package com.github.freeman.bootcamp.auth
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.github.freeman.bootcamp.MainMenuScreen
+import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,21 +35,54 @@ class FirebaseAuthActivityTest {
     }
 
     @Test
+    fun containsCorrectButtonsWhenNotSignedIn() {
+        composeRule.onNodeWithTag("google_sign_in_button").assertIsDisplayed()
+        composeRule.onNodeWithTag("anonymous_sign_in_button").assertIsDisplayed()
+        composeRule.onNodeWithTag("create_profile_button").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("delete_button").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("sign_out_button").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun containsCorrectTextWhenNotSignedIn() {
+        composeRule.onNodeWithTag("sign_in_info").assertTextContains("Not signed in")
+    }
+
+    @Test
+    fun containsCorrectButtonsWhenAnonymouslySignedIn() {
+        composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
+        composeRule.onNodeWithTag("create_profile_button").assertIsDisplayed()
+        composeRule.onNodeWithTag("delete_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun containsCorrectTextWhenAnonymouslySignedIn() {
+        composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
+        composeRule.onNodeWithTag("sign_in_info").assertTextContains("Signed in anonymously")
+    }
+
+    @Test
+    fun createProfileButtonsLaunchesTheActivity() {
+        Intents.init()
+
+        composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
+        composeRule.onNodeWithTag("create_profile_button").performClick()
+        Intents.intended(IntentMatchers.hasComponent(ProfileCreationActivity::class.java.name))
+
+        Intents.release()
+    }
+
+    @Test
     fun deleteGoogleAccountResultsInCorrectMessage() {
+        composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
         composeRule.onNodeWithTag("delete_button").performClick()
         composeRule.onNodeWithTag("sign_in_info").assertTextContains("Account deleted")
     }
 
     @Test
-    fun signOutResultsInCorrectMessage() {
-        composeRule.onNodeWithTag("sign_out_button").performClick()
-        composeRule.onNodeWithTag("sign_in_info").assert(hasText("Signed out") or hasText("Not signed in"))
-    }
-
-    @Test
     fun signInResultsInCorrectLayout() {
 
-        composeRule.onNodeWithTag("sign_in_button").performClick()
+        composeRule.onNodeWithTag("google_sign_in_button").performClick()
         device.wait(
             Until.findObject(By.textContains("Google")), 30000
         )

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
@@ -2,6 +2,7 @@ package com.github.freeman.bootcamp.auth
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.platform.app.InstrumentationRegistry
@@ -11,6 +12,7 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.github.freeman.bootcamp.MainMenuScreen
 import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity
+import okhttp3.internal.wait
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,30 +37,36 @@ class FirebaseAuthActivityTest {
     }
 
     @Test
-    fun containsCorrectButtonsWhenNotSignedIn() {
+    fun containsCorrectButtonsAndTextWhenNotSignedIn() {
         composeRule.onNodeWithTag("google_sign_in_button").assertIsDisplayed()
         composeRule.onNodeWithTag("anonymous_sign_in_button").assertIsDisplayed()
-        composeRule.onNodeWithTag("create_profile_button").assertIsNotDisplayed()
-        composeRule.onNodeWithTag("delete_button").assertIsNotDisplayed()
-        composeRule.onNodeWithTag("sign_out_button").assertIsNotDisplayed()
-    }
-
-    @Test
-    fun containsCorrectTextWhenNotSignedIn() {
         composeRule.onNodeWithTag("sign_in_info").assertTextContains("Not signed in")
     }
 
     @Test
-    fun containsCorrectButtonsWhenAnonymouslySignedIn() {
+    fun containsCorrectButtonsAndTextWhenAnonymouslySignedIn() {
         composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
+        device.wait(
+            Until.findObject(By.textContains("anonymously")), 30000
+        )
         composeRule.onNodeWithTag("create_profile_button").assertIsDisplayed()
         composeRule.onNodeWithTag("delete_button").assertIsDisplayed()
+        composeRule.onNodeWithTag("sign_in_info").assertTextContains("Signed in anonymously")
+
+        composeRule.onNodeWithTag("delete_button").performClick()
     }
 
     @Test
-    fun containsCorrectTextWhenAnonymouslySignedIn() {
+    fun deleteGoogleAccountResultsInCorrectMessage() {
         composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
-        composeRule.onNodeWithTag("sign_in_info").assertTextContains("Signed in anonymously")
+        device.wait(
+            Until.findObject(By.textContains("anonymously")), 30000
+        )
+        composeRule.onNodeWithTag("delete_button").performClick()
+        device.wait(
+            Until.findObject(By.textContains("Google")), 30000
+        )
+        composeRule.onNodeWithTag("sign_in_info").assertTextContains("Account deleted")
     }
 
     @Test
@@ -66,22 +74,20 @@ class FirebaseAuthActivityTest {
         Intents.init()
 
         composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
+        device.wait(
+            Until.findObject(By.textContains("anonymously")), 30000
+        )
         composeRule.onNodeWithTag("create_profile_button").performClick()
         Intents.intended(IntentMatchers.hasComponent(ProfileCreationActivity::class.java.name))
+
+        Espresso.pressBack()
+        composeRule.onNodeWithTag("delete_button").performClick()
 
         Intents.release()
     }
 
     @Test
-    fun deleteGoogleAccountResultsInCorrectMessage() {
-        composeRule.onNodeWithTag("anonymous_sign_in_button").performClick()
-        composeRule.onNodeWithTag("delete_button").performClick()
-        composeRule.onNodeWithTag("sign_in_info").assertTextContains("Account deleted")
-    }
-
-    @Test
     fun signInResultsInCorrectLayout() {
-
         composeRule.onNodeWithTag("google_sign_in_button").performClick()
         device.wait(
             Until.findObject(By.textContains("Google")), 30000

--- a/app/src/main/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivity.kt
@@ -1,7 +1,10 @@
 package com.github.freeman.bootcamp.auth
 
+import android.content.ContentValues.TAG
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
@@ -19,7 +22,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
+import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
 
 
 /**
@@ -38,7 +46,11 @@ class FirebaseAuthActivity : ComponentActivity() {
         signInInfo = if (currentUser == null) {
             "Not signed in"
         } else {
-            "Signed in as : " + currentUser.email
+            if (currentUser.isAnonymous) {
+                "Signed in anonymously"
+            } else {
+                "Signed in as : " + currentUser.email
+            }
         }
         signInLauncher = registerForActivityResult (
             FirebaseAuthUIActivityResultContract()
@@ -47,6 +59,7 @@ class FirebaseAuthActivity : ComponentActivity() {
                 res,
                 { email -> signInInfo = "Signed in as : $email" },
                 { errorMsg -> signInInfo = errorMsg.toString() }
+
             )
         }
 
@@ -57,12 +70,25 @@ class FirebaseAuthActivity : ComponentActivity() {
                 )
             }
         }
+
+
     }
 
+
     /**
-     * Deletes the google account from the device
+     * Deletes the 'Guess It!' account from the device
      */
-    fun deleteGoogleAccount() {
+    fun deleteAccount() {
+        //delete profile from 'Realtime Database' Firebase
+        val uid = Firebase.auth.currentUser?.uid
+        val dbrefProfile = Firebase.database.getReference("profiles/$uid")
+        dbrefProfile.removeValue()
+
+        //delete profile pic from 'Storage' Firebase
+        val stgref = Firebase.storage.getReference("profiles/$uid/picture/pic.jpg")
+        stgref.delete()
+
+        //delete account from 'Authentication' Firebase
         authenticator.delete(this) { signInInfo = "Account deleted" }
     }
 
@@ -79,11 +105,37 @@ class FirebaseAuthActivity : ComponentActivity() {
     fun signOutOfGoogleAccount() {
         authenticator.signOut(this) { signInInfo = "Signed out" }
     }
+
+    /**
+     * Signs in with anonymous account
+     */
+    fun signInAnonymously() {
+        Firebase.auth.signInAnonymously().addOnCompleteListener(this) { task ->
+            if (task.isSuccessful) {
+                // Sign in success, update UI with the signed-in user's information
+                Log.d(TAG, "signInAnonymously:success")
+                val user = Firebase.auth.currentUser
+                signInInfo = "Signed in anonymously"
+            } else {
+                // If sign in fails, display a message to the user.
+                Log.w(TAG, "signInAnonymously:failure", task.exception)
+                Toast.makeText(baseContext, "Authentication failed", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 }
 
 @Composable
 fun AuthenticationForm(signInInfo: String) {
     val context = LocalContext.current
+
+    /* //TODO: Display "Create profile" only when there is an existing profile and "Delete profile" where there isn't
+    var profileExists = false
+    FirebaseUtilities.profileExists(FirebaseAuth.getInstance().currentUser, Firebase.database.reference)
+        .thenAccept {
+            profileExists = it
+        }
+     */
 
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -95,32 +147,72 @@ fun AuthenticationForm(signInInfo: String) {
             text = signInInfo,
         )
 
-        ElevatedButton(
-            modifier = Modifier.testTag("sign_in_button"),
-            onClick = {
-                (context as? FirebaseAuthActivity)?.signIntoGoogleAccount()
-                if (FirebaseAuth.getInstance().currentUser != null) {
+        if (FirebaseAuth.getInstance().currentUser == null) {
+            // if the user is not authenticated
+
+            Spacer(modifier = Modifier.size(24.dp))
+
+            ElevatedButton(
+                modifier = Modifier.testTag("google_sign_in_button"),
+                onClick = {
+                    (context as? FirebaseAuthActivity)?.signIntoGoogleAccount()
+                })
+            { Text("Sign in with Google") }
+
+            Spacer(modifier = Modifier.size(24.dp))
+
+            ElevatedButton(
+                modifier = Modifier.testTag("anonymous_sign_in_button"),
+                onClick = {
+                    (context as? FirebaseAuthActivity)?.signInAnonymously()
+                })
+            { Text("Sign in as guest") }
+
+
+
+        } else {
+            // if the user is authenticated (with Google or anonymously)
+
+            Spacer(modifier = Modifier.size(24.dp))
+
+
+            // if the user doesn't have a 'Guess It!' account
+            ElevatedButton(
+                modifier = Modifier.testTag("create_profile_button"),
+                onClick = {
                     context.startActivity(Intent(context, ProfileCreationActivity::class.java))
-                }
-            })
-        { Text("Sign in") }
+                })
+            { Text("Create \'Guess It!\' profile") }
 
-        Spacer(modifier = Modifier.size(24.dp))
+            Spacer(modifier = Modifier.size(24.dp))
 
-        ElevatedButton(
-            modifier = Modifier.testTag("sign_out_button"),
-            onClick = {
-                (context as? FirebaseAuthActivity)?.signOutOfGoogleAccount()
-            })
-        { Text("Sign out") }
+            // if the user has a 'Guess It!' account
+            ElevatedButton(
+                modifier = Modifier.testTag("delete_button"),
+                onClick = {
+                    (context as? FirebaseAuthActivity)?.deleteAccount()
+                })
+            { Text("Delete \'Guess It!\' account") }
 
-        Spacer(modifier = Modifier.size(24.dp))
 
-        ElevatedButton(
-            modifier = Modifier.testTag("delete_button"),
-            onClick = {
-                (context as? FirebaseAuthActivity)?.deleteGoogleAccount()
-            })
-        { Text("Delete account") }
+
+            Spacer(modifier = Modifier.size(24.dp))
+
+            if (FirebaseAuth.getInstance().currentUser?.isAnonymous == false) {
+                // if the user is authenticated with google
+
+                ElevatedButton(
+                    modifier = Modifier.testTag("sign_out_button"),
+                    onClick = {
+                        (context as? FirebaseAuthActivity)?.signOutOfGoogleAccount()
+                    })
+                { Text("Sign out from Google authentication") }
+
+                Spacer(modifier = Modifier.size(24.dp))
+            }
+
+
+        }
+
     }
 }

--- a/app/src/main/java/com/github/freeman/bootcamp/utilities/firebase/FirebaseUtilities.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/utilities/firebase/FirebaseUtilities.kt
@@ -98,7 +98,7 @@ object FirebaseUtilities {
             future.complete(false)
         } else {
             // if the email exists, the profile exists too
-            databaseGet(dbRef.child("profiles/${user.uid}/email"))
+            databaseGet(dbRef.child("profiles/${user.uid}/username"))
                 .thenAccept {
                     future.complete(it != "")
                 }


### PR DESCRIPTION
I added a possibility to create an account without google. 
I also change the way the button are display in the sign-in activity, i.e. the buttons appear only when needed. An exception : the "Delete profile" & "Create profile" appears no matter if you already have or not a 'guess it' profile. I let it that way, because I lost so much time looking for a solution to retrieve the info I needed from the database before continue the execution of the rest of the code, and I didn't find it. So, it will probably be for another sprint. 

P-S: Now, when the profile is deleted, it completely disapears from the Firebase (Realtime, Storage & Authentication). 