### PR TITLE
Guessers' Timer & Score Bug Fix

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -110,6 +110,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-904475017">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-817789376">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -110,6 +110,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1025241737">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-904475017">
           <value>
             <AndroidTestResultsTableState>
@@ -192,6 +205,19 @@
           </value>
         </entry>
         <entry key="206097079">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="222130693">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/EndScoreboardTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/EndScoreboardTest.kt
@@ -39,8 +39,8 @@ class EndScoreboardTest {
     fun init() {
         gameEnded = true
         composeRule.setContent {
-            val gameId = "TestGameId"
-            val dbRef = Firebase.database.getReference("Games/$gameId")
+            val gameId = "testgameid"
+            val dbRef = Firebase.database.getReference("games/$gameId")
             reinitialise(dbRef, playerIds.toSet())
 
             initFirebaseScores(dbRef, playerIds, scores)

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/PopUpsTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/PopUpsTest.kt
@@ -7,11 +7,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.freeman.bootcamp.games.guessit.CorrectAnswerPopUp
 import com.github.freeman.bootcamp.games.guessit.TimerOverPopUp
-import com.github.freeman.bootcamp.games.guessit.TimerScreen
 import com.github.freeman.bootcamp.games.guessit.guessing.Guess
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,7 +18,7 @@ class PopUpsTest {
     @get:Rule
     val composeRule = createComposeRule()
 
-     private val guess = Guess(guesser = "Me", guess = "ThePerfectWord")
+     private val guess = Guess(guesser = "Me", guesserId = "ID", guess = "ThePerfectWord")
 
     private fun setPopUp(type: String) {
         composeRule.setContent {

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/ScoreActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/ScoreActivityTest.kt
@@ -42,8 +42,8 @@ class ScoreActivityTest {
     fun init() {
         gameEnded = false
         composeRule.setContent {
-            val gameId = "TestGameId"
-            val dbRef = Firebase.database.getReference("Games/$gameId")
+            val gameId = "testgameid"
+            val dbRef = Firebase.database.getReference("games/$gameId")
             reinitialise(dbRef, playerIds.toSet())
 
            initFirebaseScores(dbRef, playerIds, scores)
@@ -106,7 +106,7 @@ class ScoreActivityTest {
 // Initialises the player scores of the test game on the Firebase
 fun initFirebaseScores(dbRef: DatabaseReference, playerIds: List<String>, scores: Map<String, Int>) {
     for (id in playerIds) {
-        val dbScoreRef = dbRef.child("Players/$id/score")
+        val dbScoreRef = dbRef.child("players/$id/score")
         FirebaseUtilities.databaseGetLong(dbScoreRef)
             .thenAccept {
                 dbScoreRef.setValue(scores[id])

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/TimerTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/TimerTest.kt
@@ -8,7 +8,6 @@ import com.github.freeman.bootcamp.games.guessit.TimerScreen
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
-import com.google.firebase.storage.ktx.storage
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +27,7 @@ class TimerTest {
         val dbref = Firebase.database.getReference("games/testgameid/current/current_timer")
         composeRule.setContent {
             BootcampComposeTheme {
-                TimerScreen(dbref, 100, 100L)
+                TimerScreen(dbref, 100L)
             }
         }
     }

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/ScoreActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/ScoreActivity.kt
@@ -251,7 +251,7 @@ fun Scoreboard(playerScores: List<Pair<String?, Int>>, modifier: Modifier) {
         ) {
             Text(
                 text = SCORES_TITLE,
-                style = MaterialTheme.typography.h6,
+                style = MaterialTheme.typography.subtitle1,
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .testTag("scoresTitle")

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/TimerActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/TimerActivity.kt
@@ -43,7 +43,7 @@ class TimerActivity : ComponentActivity() {
 
 @Composable
 fun TimerScreen(dbrefTimer: DatabaseReference, time: Long, size: Int = 70, fontSize: TextUnit = 30.sp,
-                color: Color= Purple80) {
+                color: Color= Purple80, textColor: Color = Color.DarkGray) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -54,6 +54,7 @@ fun TimerScreen(dbrefTimer: DatabaseReference, time: Long, size: Int = 70, fontS
             dbrefTimer = dbrefTimer,
             totalTime = time * 1000L,
             activeBarColor = color,
+            textColor = textColor,
             fontSize = fontSize,
             modifier = Modifier
                 .size((0.8*size).dp)
@@ -67,6 +68,7 @@ fun Timer(
     dbrefTimer: DatabaseReference,
     totalTime: Long,
     activeBarColor: Color,
+    textColor: Color,
     fontSize: TextUnit,
     modifier: Modifier = Modifier
 ) {
@@ -93,17 +95,17 @@ fun Timer(
     ) {
         TimerCircles(modifier, activeBarColor, strokeWidth, value)
 
-        TimerText(currentTime, fontSize)
+        TimerText(currentTime, fontSize, textColor)
     }
 }
 
 @Composable
-fun TimerText(currentTime: Long, fontSize: TextUnit) {
+fun TimerText(currentTime: Long, fontSize: TextUnit, textColor: Color) {
     Text(
         text = (currentTime / 1000L).toString(),
         fontSize = fontSize,
         fontWeight = FontWeight.Bold,
-        color = Color.DarkGray
+        color = textColor
     )
 }
 

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/TimerActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/TimerActivity.kt
@@ -17,10 +17,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.*
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.ui.theme.Purple80
 import com.google.firebase.database.DatabaseReference
@@ -38,14 +35,15 @@ class TimerActivity : ComponentActivity() {
 
         setContent {
             BootcampComposeTheme {
-                TimerScreen(dbrefTimer, 100, 100L)
+                TimerScreen(dbrefTimer, 100L)
             }
         }
     }
 }
 
 @Composable
-fun TimerScreen(dbrefTimer: DatabaseReference, size: Int, time: Long, color: Color= Purple80) {
+fun TimerScreen(dbrefTimer: DatabaseReference, time: Long, size: Int = 70, fontSize: TextUnit = 30.sp,
+                color: Color= Purple80) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -56,6 +54,7 @@ fun TimerScreen(dbrefTimer: DatabaseReference, size: Int, time: Long, color: Col
             dbrefTimer = dbrefTimer,
             totalTime = time * 1000L,
             activeBarColor = color,
+            fontSize = fontSize,
             modifier = Modifier
                 .size((0.8*size).dp)
                 .testTag("timer")
@@ -68,6 +67,7 @@ fun Timer(
     dbrefTimer: DatabaseReference,
     totalTime: Long,
     activeBarColor: Color,
+    fontSize: TextUnit,
     modifier: Modifier = Modifier
 ) {
     val initialValue = 1f
@@ -93,15 +93,15 @@ fun Timer(
     ) {
         TimerCircles(modifier, activeBarColor, strokeWidth, value)
 
-        TimerText(currentTime)
+        TimerText(currentTime, fontSize)
     }
 }
 
 @Composable
-fun TimerText(currentTime: Long) {
+fun TimerText(currentTime: Long, fontSize: TextUnit) {
     Text(
         text = (currentTime / 1000L).toString(),
-        fontSize = 40.sp,
+        fontSize = fontSize,
         fontWeight = FontWeight.Bold,
         color = Color.DarkGray
     )

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingActivity.kt
@@ -215,7 +215,7 @@ private fun ControlsBar(
     val dbrefTimer = dbref.child("current/current_timer")
 
     Row(modifier = Modifier.padding(12.dp), horizontalArrangement = Arrangement.SpaceAround) {
-        TimerScreen(dbrefTimer,100, 60L)
+        TimerScreen(dbrefTimer,60L)
         MenuItems(
             R.drawable.ic_undo,
             LocalContext.current.getString(R.string.undo),

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/Guess.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/Guess.kt
@@ -2,5 +2,6 @@ package com.github.freeman.bootcamp.games.guessit.guessing
 
 data class Guess(
     val guesser: String? = null,
+    val guesserId: String? = null,
     val guess: String? = null
 )

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
@@ -13,12 +13,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
@@ -34,10 +32,9 @@ import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Compa
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Companion.pointsReceived
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Companion.roundNb
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Companion.turnNb
-import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
-import com.github.freeman.bootcamp.ui.theme.Purple40
 import com.github.freeman.bootcamp.utilities.BitmapHandler
+import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.DataSnapshot

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
@@ -345,8 +345,10 @@ fun GuessingScreen(dbrefGame: DatabaseReference, gameId: String = LocalContext.c
                     )
                 }
 
-                val dbRefTimer = Firebase.database.getReference("games/$gameId").child("current/current_timer")
-                TimerScreen(dbRefTimer, 60L, fontSize = 30.sp, textColor = Color.White)
+                if (timer != "useless") {
+                    val dbRefTimer = Firebase.database.getReference("games/$gameId").child("current/current_timer")
+                    TimerScreen(dbRefTimer, 60L, fontSize = 30.sp, textColor = Color.LightGray)
+                }
 
                 ScoreScreen(dbrefGame)
             }

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
@@ -28,6 +28,7 @@ import com.github.freeman.bootcamp.R
 import com.github.freeman.bootcamp.games.guessit.CorrectAnswerPopUp
 import com.github.freeman.bootcamp.games.guessit.ScoreScreen
 import com.github.freeman.bootcamp.games.guessit.TimerOverPopUp
+import com.github.freeman.bootcamp.games.guessit.TimerScreen
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Companion.answer
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Companion.pointsReceived
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity.Companion.roundNb
@@ -344,6 +345,10 @@ fun GuessingScreen(dbrefGame: DatabaseReference, gameId: String = LocalContext.c
                             .align(Alignment.Center)
                     )
                 }
+
+                val dbRefTimer = Firebase.database.getReference("games/$gameId").child("current/current_timer")
+                TimerScreen(dbRefTimer, 60L, fontSize = 30.sp, textColor = Color.White)
+
                 ScoreScreen(dbrefGame)
             }
 

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
@@ -83,8 +83,8 @@ fun GuessItem(guess: Guess, answer: String, dbrefGame: DatabaseReference, artist
             .padding(8.dp)
             .testTag("guessItem")
     ) {
-        if (guess.guess?.lowercase() == answer.lowercase()) {
-            val userId = Firebase.auth.currentUser?.uid
+        val userId = Firebase.auth.currentUser?.uid
+        if (guess.guess?.lowercase() == answer.lowercase() && guess.guesserId == userId) {
             val dbGuesserScoreRef = dbrefGame.child("players/$userId/score")
             val dbArtistScoreRef = dbrefGame.child("players/$artistId/score")
             val correctGuessesRef = dbrefGame.child("current/correct_guesses")
@@ -126,7 +126,7 @@ fun GuessItem(guess: Guess, answer: String, dbrefGame: DatabaseReference, artist
                     }
                 }
 
-            val gs = Guess(guess.guesser, answer)
+            val gs = Guess(guess.guesser, guess.guesserId, answer)
             CorrectAnswerPopUp(gs = gs)
 
         }
@@ -217,7 +217,6 @@ fun GuessingScreen(dbrefGame: DatabaseReference, gameId: String = LocalContext.c
         override fun onDataChange(snapshot: DataSnapshot) {
             if (snapshot.exists()) {
                 val guessesList = snapshot.getValue<ArrayList<Guess>>()!!
-
                 guesses = guessesList.toTypedArray()
             }
         }
@@ -370,7 +369,7 @@ fun GuessingScreen(dbrefGame: DatabaseReference, gameId: String = LocalContext.c
                     guess = guess,
                     onGuessChange = { guess = it },
                     onSendClick = {
-                        val gs = Guess(guesser = username, guess = guess)
+                        val gs = Guess(guesser = username, guesserId = uid, guess = guess)
                         val guessId = guesses.size.toString()
                         dbrefGame.child("guesses").child(guessId).setValue(gs)
 

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,7 +1,8 @@
-17:01:36.516 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-17:01:36.757 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
-17:03:11.026 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 351ms, init: 0ms
-17:10:08.890 [Thread-0] INFO com.firebase.server.forge.App$ - Attempting graceful shutdown.
-17:10:08.956 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.Terminator$Terminator - 1 actors left to terminate: sdp-guess-it-default-rtdb
-17:10:08.972 [NamespaceSystem-akka.actor.default-dispatcher-27] INFO com.firebase.core.namespace.NamespaceActor - stopped namespace actor for sdp-guess-it-default-rtdb
-17:10:08.979 [Thread-0] INFO com.firebase.server.forge.App$ - Graceful shutdown complete.
+12:48:41.358 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+12:48:41.609 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+12:48:52.277 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it successfully activated FBKV (SurveyIdle(0)) wait: 292ms, init: 0ms
+12:50:44.183 [FirebaseWorkerPool-1-3] WARN com.firebase.core.persistence.backend.dummy.EmulatorMetadataPersistence - Multiple projectIds are not recommended in single project mode. Requested 
+namespace sdp-guess-it-default-rtdb, but the emulator is configured for sdp-guess-it. To 
+opt-out of single project mode add/set the single_project_mode: false property in 
+the firebase.json emulators config. 
+12:50:44.288 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 44ms, init: 0ms

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,3 +1,7 @@
-21:04:09.985 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-21:04:10.256 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
-21:07:22.601 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 384ms, init: 0ms
+17:01:36.516 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+17:01:36.757 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+17:03:11.026 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 351ms, init: 0ms
+17:10:08.890 [Thread-0] INFO com.firebase.server.forge.App$ - Attempting graceful shutdown.
+17:10:08.956 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.Terminator$Terminator - 1 actors left to terminate: sdp-guess-it-default-rtdb
+17:10:08.972 [NamespaceSystem-akka.actor.default-dispatcher-27] INFO com.firebase.core.namespace.NamespaceActor - stopped namespace actor for sdp-guess-it-default-rtdb
+17:10:08.979 [Thread-0] INFO com.firebase.server.forge.App$ - Graceful shutdown complete.

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,8 +1,8 @@
-12:48:41.358 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-12:48:41.609 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
-12:48:52.277 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it successfully activated FBKV (SurveyIdle(0)) wait: 292ms, init: 0ms
-12:50:44.183 [FirebaseWorkerPool-1-3] WARN com.firebase.core.persistence.backend.dummy.EmulatorMetadataPersistence - Multiple projectIds are not recommended in single project mode. Requested 
+14:59:23.480 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+14:59:23.949 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+14:59:58.363 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it successfully activated FBKV (SurveyIdle(0)) wait: 229ms, init: 0ms
+15:04:37.405 [FirebaseWorkerPool-1-3] WARN com.firebase.core.persistence.backend.dummy.EmulatorMetadataPersistence - Multiple projectIds are not recommended in single project mode. Requested 
 namespace sdp-guess-it-default-rtdb, but the emulator is configured for sdp-guess-it. To 
 opt-out of single project mode add/set the single_project_mode: false property in 
 the firebase.json emulators config. 
-12:50:44.288 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 44ms, init: 0ms
+15:04:37.640 [NamespaceSystem-akka.actor.default-dispatcher-10] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 48ms, init: 0ms


### PR DESCRIPTION
This small PR adds a timer to the GuessingActivity and adjusts the size of all in-game timers to occupy less space, whilst still being visible. The timer only starts once the artist has chosen their topic.

Also, this fixes bug where if a player A guesses correctly this made everyone get a point rather than only player A (and potentially the artist, of course).