### PR TITLE
Chat in guessing screen

### DIFF
--- a/app/src/androidTest/java/com/github/freeman/bootcamp/PopUpsTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/PopUpsTest.kt
@@ -18,7 +18,7 @@ class PopUpsTest {
     @get:Rule
     val composeRule = createComposeRule()
 
-     private val guess = Guess(guesser = "Me", guesserId = "ID", guess = "ThePerfectWord")
+     private val guess = Guess(guesser = "Me", guesserId = "ID", message = "ThePerfectWord")
 
     private fun setPopUp(type: String) {
         composeRule.setContent {
@@ -50,7 +50,7 @@ class PopUpsTest {
 
         val sb = StringBuilder()
         sb.append(guess.guesser).append(" made a correct guess: \n\nThe word was \"")
-            .append(guess.guess)
+            .append(guess.message)
             .append("\"!")
 
         composeRule.onNodeWithTag("popUpText").assertTextContains(sb.toString())

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/PopUps.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/PopUps.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import com.github.freeman.bootcamp.R
 import com.github.freeman.bootcamp.games.guessit.guessing.Guess
-import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.ui.theme.Purple40
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.ktx.database
@@ -88,7 +87,7 @@ fun CorrectAnswerPopUp(gs: Guess) {
     }
 
     sb.append(" made a correct guess: \n\nThe word was \"")
-        .append(gs.guess)
+        .append(gs.message)
         .append("\"!")
 
     PopUpScreen(text = sb.toString())

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/PopUps.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/PopUps.kt
@@ -23,7 +23,7 @@ import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 
 /**
- * This is the squeletton of any pop up
+ * This is the skeleton of any pop up
  * @param text: The text that will be displayed inside the pop-up
  */
 @Composable

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/Guess.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/Guess.kt
@@ -1,7 +1,10 @@
 package com.github.freeman.bootcamp.games.guessit.guessing
 
+/**
+ * Represents a message typed in the guessing screen
+ */
 data class Guess(
     val guesser: String? = null,
     val guesserId: String? = null,
-    val guess: String? = null
+    val message: String? = null
 )

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
@@ -98,7 +98,7 @@ fun GuessItem(guess: Guess, answer: String, dbrefGame: DatabaseReference, artist
             .testTag("guessItem")
     ) {
         val userId = Firebase.auth.currentUser?.uid
-        if (guess.guess?.lowercase() == answer.lowercase() && guess.guesserId == userId) {
+        if (guess.message?.lowercase() == answer.lowercase() && guess.guesserId == userId) {
             val dbGuesserScoreRef = dbrefGame
                 .child(context.getString(R.string.players_path))
                 .child(userId.toString())
@@ -151,7 +151,11 @@ fun GuessItem(guess: Guess, answer: String, dbrefGame: DatabaseReference, artist
 
         }
 
-        Text(text = "${guess.guesser} tries \"${guess.guess}\"")
+        if (!(guess.message?.lowercase() == GuessingActivity.answer.lowercase() && guess.guesserId == userId)) {
+            Text(text = "${guess.guesser} : ${guess.message}")
+        } else {
+            Text(text = "${guess.guesser} : ****")
+        }
     }
 }
 
@@ -402,7 +406,7 @@ fun GuessingScreen(dbrefGame: DatabaseReference, context: Context) {
                     guess = guess,
                     onGuessChange = { guess = it },
                     onSendClick = {
-                        val gs = Guess(guesser = username, guesserId = uid, guess = guess)
+                        val gs = Guess(guesser = username, guesserId = uid, message = guess)
                         val guessId = guesses.size.toString()
                         dbrefGame
                             .child(context.getString(R.string.guesses_path))


### PR DESCRIPTION
This adds a way for a guesser to chat and guess in the same area of the screen.

A message is displayed by the name and the message content. if the message is the actual answer of the round, the message is censored with stars and thus not visible by other players.