### PR TITLE
Private lobbies

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -29,6 +29,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1653819630">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1517412785">
           <value>
             <AndroidTestResultsTableState>
@@ -82,6 +95,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1352436517">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1160862331">
           <value>
             <AndroidTestResultsTableState>
@@ -123,7 +149,33 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1015933320">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-904475017">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-872443703">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -177,6 +229,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-382845038">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-308797413">
           <value>
             <AndroidTestResultsTableState>
@@ -192,6 +257,19 @@
           </value>
         </entry>
         <entry key="-30102969">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="126344436">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -282,6 +360,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="1242169909">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1303645474">
           <value>
             <AndroidTestResultsTableState>
@@ -309,6 +400,19 @@
           </value>
         </entry>
         <entry key="1345494472">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1357786786">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -447,6 +551,19 @@
                 <map>
                   <entry key="39V4C19703010730" value="120" />
                   <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1995673096">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -162,6 +162,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1005310326">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-904475017">
           <value>
             <AndroidTestResultsTableState>
@@ -439,6 +452,19 @@
           </value>
         </entry>
         <entry key="1450096635">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1456877821">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Embedded JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/CreatePublicPrivateActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/CreatePublicPrivateActivityTest.kt
@@ -1,0 +1,97 @@
+package com.github.freeman.bootcamp
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity
+import com.github.freeman.bootcamp.games.guessit.lobbies.MainScreen
+import com.github.freeman.bootcamp.games.guessit.lobbies.TopAppbarPublicPrivate
+import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreatePublicPrivateActivityTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun initScreen() {
+        composeRule.setContent {
+            BootcampComposeTheme {
+                TopAppbarPublicPrivate()
+
+                MainScreen()
+            }
+        }
+    }
+
+    @Test
+    fun mainScreenIsDisplayed() {
+        composeRule.onNodeWithTag("createPublicPrivateMainScreen").assertIsDisplayed()
+    }
+
+    @Test
+    fun topAppBarIsDisplayed() {
+        composeRule.onNodeWithTag("topAppbarPublicPrivate").assertIsDisplayed()
+    }
+
+    @Test
+    fun topAppBarCanBeClicked() {
+        composeRule.onNodeWithTag("topAppbarPublicPrivateButton").assertHasClickAction()
+        composeRule.onNodeWithTag("topAppbarPublicPrivateButton").performClick()
+        composeRule.onNodeWithTag("topAppbarPublicPrivateButton").assertDoesNotExist()
+    }
+
+    @Test
+    fun publicButtonIsDisplayed() {
+        composeRule.onNodeWithTag("publicLobbyButton").assertIsDisplayed()
+    }
+
+    @Test
+    fun publicButtonCanBeClicked() {
+        composeRule.onNodeWithTag("publicLobbyButton").assertHasClickAction()
+        composeRule.onNodeWithTag("publicLobbyButton").performClick()
+        composeRule.onNodeWithTag("publicLobbyButton").assertDoesNotExist()
+    }
+
+    @Test
+    fun privateButtonIsDisplayed() {
+        composeRule.onNodeWithTag("privateLobbyButton").assertIsDisplayed()
+    }
+
+    @Test
+    fun privateButtonCanBeClicked() {
+        composeRule.onNodeWithTag("privateLobbyButton").assertHasClickAction()
+        composeRule.onNodeWithTag("privateLobbyButton").performClick()
+        composeRule.onNodeWithTag("privateLobbyButton").assertDoesNotExist()
+    }
+
+    @Test
+    fun publicButtonSendsIntent() {
+        Intents.init()
+
+        composeRule.onNodeWithTag("publicLobbyButton").performClick()
+        Intents.intended(IntentMatchers.hasComponent(GameOptionsActivity::class.java.name))
+
+        Intents.release()
+    }
+
+    @Test
+    fun privateButtonSendsIntent() {
+        Intents.init()
+
+        composeRule.onNodeWithTag("privateLobbyButton").performClick()
+        Intents.intended(IntentMatchers.hasComponent(GameOptionsActivity::class.java.name))
+
+        Intents.release()
+    }
+}

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
@@ -8,15 +8,15 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.freeman.bootcamp.games.guessit.CreateGameButton
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.NB_ROUNDS
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.NEXT
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.ROUNDS_SELECTION
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.categories
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selectedTopics
 import com.github.freeman.bootcamp.games.guessit.GameOptionsScreen
-import com.github.freeman.bootcamp.games.guessit.JoinGameButton
-import com.github.freeman.bootcamp.games.guessit.TopAppbarCreateJoin
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreateGameButton
+import com.github.freeman.bootcamp.games.guessit.lobbies.JoinGameButton
+import com.github.freeman.bootcamp.games.guessit.lobbies.TopAppbarCreateJoin
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseSingletons
 import com.google.firebase.database.DatabaseReference
@@ -134,7 +134,7 @@ class GameOptionsActivityTest {
         dbRef.child("profiles/null/username").setValue("test_username")
         composeRule.setContent {
             BootcampComposeTheme {
-                GameOptionsScreen(dbRef)
+                GameOptionsScreen(dbRef, "public")
             }
         }
     }

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
@@ -109,6 +109,7 @@ class GameOptionsActivityTest {
             }
         }
         composeRule.onNodeWithTag("createGameButton").performClick()
+        composeRule.onNodeWithTag("publicLobbyButton").performClick()
         composeRule.onNodeWithTag("gameOptionsScreen").assertIsDisplayed()
     }
 

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
@@ -129,13 +129,20 @@ class GameOptionsActivityTest {
         // assertFalse(selectedTopics.isEmpty())
     }
 
+    @Test
+    fun passwordInputIsDisplayed() {
+        setGameOptionsScreen()
+
+        composeRule.onNodeWithTag("passwordInput").assertIsDisplayed()
+    }
+
     private fun setGameOptionsScreen() {
         val dbRef = initDatabase()
         dbRef.child("profiles/null/email").setValue("test@mail.abc")
         dbRef.child("profiles/null/username").setValue("test_username")
         composeRule.setContent {
             BootcampComposeTheme {
-                GameOptionsScreen(dbRef, "public")
+                GameOptionsScreen(dbRef, "private")
             }
         }
     }

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/LobbyListTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/LobbyListTest.kt
@@ -1,33 +1,19 @@
 package com.github.freeman.bootcamp
 
-import android.widget.Toast
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import com.github.freeman.bootcamp.games.guessit.*
 import com.github.freeman.bootcamp.games.guessit.lobbies.*
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
-import com.github.freeman.bootcamp.utilities.firebase.FirebaseSingletons
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities.getGameDBRef
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.database.DatabaseReference
-import com.google.firebase.ktx.Firebase
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class LobbyListTest {
-
-    private fun initDatabase(): DatabaseReference {
-        FirebaseEmulator.init()
-        return FirebaseSingletons.database.get().database.reference
-    }
 
     @get:Rule
     val composeRule = createComposeRule()
@@ -37,12 +23,10 @@ class LobbyListTest {
         composeRule.setContent {
             val context = LocalContext.current
 
-            val dbRef = initDatabase()
-
-            val gameData = GameData(
+            val gameDataPublic = GameData(
                 Current = Current(
                     correct_guesses = 0,
-                    current_artist = "test_artist_id",
+                    current_artist = "test_artist_id_1",
                     current_round = 0,
                     current_state = "waiting for players",
                     current_turn = 0,
@@ -50,51 +34,47 @@ class LobbyListTest {
                 ),
                 Parameters = Parameters(
                     category = "Objects",
-                    host_id = "test_host_id",
+                    host_id = "test_host_id_1",
                     nb_players = 1,
                     nb_rounds = 5,
                     type = "public",
                     password = ""
                 ),
-                Players = mapOf(Pair("test_player_id", Player(0, false))),
-                lobby_name = "test's room"
+                Players = mapOf(Pair("test_player_id_1", Player(0, false))),
+                lobby_name = "test_1's room"
             )
 
-            getGameDBRef(context).setValue(gameData)
+            val gameDataPrivate = GameData(
+                Current = Current(
+                    correct_guesses = 0,
+                    current_artist = "test_artist_id_2",
+                    current_round = 0,
+                    current_state = "waiting for players",
+                    current_turn = 0,
+                    current_timer = "unused"
+                ),
+                Parameters = Parameters(
+                    category = "Objects",
+                    host_id = "test_host_id_2",
+                    nb_players = 1,
+                    nb_rounds = 5,
+                    type = "private",
+                    password = "abc"
+                ),
+                Players = mapOf(Pair("test_player_id_2", Player(0, false))),
+                lobby_name = "test_2's room"
+            )
+
+            getGameDBRef(context, "testPublicGameId").setValue(gameDataPublic)
+            getGameDBRef(context, "testPrivateGameId").setValue(gameDataPrivate)
 
             BootcampComposeTheme {
-                val password = remember { mutableStateOf("") }
-                val enterPassword = remember { mutableStateOf(false) }
-                val lobby = remember { mutableStateOf(Lobby("", "", 0, 0, "", "")) }
-
-                Column {
-                    TopAppbarLobbies()
-
-                    androidx.compose.material.Surface(
-                        modifier = Modifier.fillMaxSize(),
-                        color = Color(0xFFF1F1F1)
-                    ) {
-                        if (!enterPassword.value) {
-                            LobbyList(dbRef, enterPassword, lobby)
-                        }
-                    }
-
-                    if (enterPassword.value) {
-                        val userId = Firebase.auth.uid
-                        EditDialog(password,
-                            LobbyListActivity.ENTER_PASSWORD_TEXT,
-                            LobbyListActivity.PASSWORD_TEXT, enterPassword) {
-                            if (lobby.value.password == it) {
-                                joinLobby(context, dbRef.child(context.getString(R.string.games_path)), userId.toString(), lobby.value)
-                            } else {
-                                Toast.makeText(context,
-                                    LobbyListActivity.WRONG_PASSWORD_TEXT, Toast.LENGTH_SHORT).show()
-                            }
-                        }
-                    }
-                }
+                MainMenuScreen()
             }
         }
+
+        composeRule.onNodeWithTag("playButton").performClick()
+        composeRule.onNodeWithTag("joiningGameButton").performClick()
     }
 
     @Test
@@ -110,5 +90,19 @@ class LobbyListTest {
     @Test
     fun lobbyListIsDisplayed() {
         composeRule.onNodeWithTag("lobbyList").assertIsDisplayed()
+    }
+
+    @Test
+    fun enteringRightPasswordEntersLobby() {
+        Intents.init()
+
+        composeRule.onNodeWithText("test_2's room").performClick()
+        composeRule.onNodeWithTag("dialogTextField").performTextInput("abc")
+        composeRule.onNodeWithTag("doneButton").performClick()
+
+        Intents.intended(IntentMatchers.hasComponent(WaitingRoomActivity::class.java.name))
+
+
+        Intents.release()
     }
 }

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/LobbyListTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/LobbyListTest.kt
@@ -1,18 +1,23 @@
 package com.github.freeman.bootcamp
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Surface
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.freeman.bootcamp.games.guessit.*
+import com.github.freeman.bootcamp.games.guessit.lobbies.*
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseSingletons
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities.getGameDBRef
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.DatabaseReference
+import com.google.firebase.ktx.Firebase
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -47,7 +52,9 @@ class LobbyListTest {
                     category = "Objects",
                     host_id = "test_host_id",
                     nb_players = 1,
-                    nb_rounds = 5
+                    nb_rounds = 5,
+                    type = "public",
+                    password = ""
                 ),
                 Players = mapOf(Pair("test_player_id", Player(0, false))),
                 lobby_name = "test's room"
@@ -56,13 +63,34 @@ class LobbyListTest {
             getGameDBRef(context).setValue(gameData)
 
             BootcampComposeTheme {
+                val password = remember { mutableStateOf("") }
+                val enterPassword = remember { mutableStateOf(false) }
+                val lobby = remember { mutableStateOf(Lobby("", "", 0, 0, "", "")) }
+
                 Column {
                     TopAppbarLobbies()
 
-                    Surface(
-                        modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F1F1)
+                    androidx.compose.material.Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = Color(0xFFF1F1F1)
                     ) {
-                        LobbyList(dbRef)
+                        if (!enterPassword.value) {
+                            LobbyList(dbRef, enterPassword, lobby)
+                        }
+                    }
+
+                    if (enterPassword.value) {
+                        val userId = Firebase.auth.uid
+                        EditDialog(password,
+                            LobbyListActivity.ENTER_PASSWORD_TEXT,
+                            LobbyListActivity.PASSWORD_TEXT, enterPassword) {
+                            if (lobby.value.password == it) {
+                                joinLobby(context, dbRef.child(context.getString(R.string.games_path)), userId.toString(), lobby.value)
+                            } else {
+                                Toast.makeText(context,
+                                    LobbyListActivity.WRONG_PASSWORD_TEXT, Toast.LENGTH_SHORT).show()
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/MainMenuTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/MainMenuTest.kt
@@ -11,10 +11,10 @@ import com.github.freeman.bootcamp.MainMenuActivity.Companion.DRAWING
 import com.github.freeman.bootcamp.MainMenuActivity.Companion.GUESSING
 import com.github.freeman.bootcamp.MainMenuActivity.Companion.PLAY
 import com.github.freeman.bootcamp.MainMenuActivity.Companion.SETTINGS
-import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity
 import com.github.freeman.bootcamp.games.guessit.chat.ChatActivity
 import com.github.freeman.bootcamp.games.guessit.drawing.DrawingActivity
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreateJoinActivity
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.videocall.VideoCallActivity
 import com.github.freeman.bootcamp.games.wordle.WordleMenu

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/WaitingRoomTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/WaitingRoomTest.kt
@@ -15,6 +15,10 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.freeman.bootcamp.games.guessit.*
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity
+import com.github.freeman.bootcamp.games.guessit.lobbies.PlayerList
+import com.github.freeman.bootcamp.games.guessit.lobbies.RoomInfo
+import com.github.freeman.bootcamp.games.guessit.lobbies.StartButton
+import com.github.freeman.bootcamp.games.guessit.lobbies.TopAppbarWaitingRoom
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseSingletons
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities.databaseGet
@@ -71,7 +75,9 @@ class WaitingRoomTest {
                     category = "Objects",
                     host_id = "test_host_id",
                     nb_players = 1,
-                    nb_rounds = 5
+                    nb_rounds = 5,
+                    type = "public",
+                    password = ""
                 ),
                 Players = mapOf(Pair("test_profile_id_1", Player(0, false)), Pair("test_profile_id_2", Player(0, false))),
                 lobby_name = "test's room"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,13 +18,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BootcampCompose"
         tools:targetApi="31" >
-        <activity
-            android:name=".auth.ProfileCreationActivity"
-            android:exported="false" >
-            <meta-data
-                android:name="android.app.lib_name"
-                android:value="" />
-        </activity>
+
         <activity
             android:name=".games.guessit.TimerActivity"
             android:exported="false" >
@@ -107,21 +101,28 @@
                 android:value="" />
         </activity>
         <activity
-            android:name=".games.guessit.CreateJoinActivity"
+            android:name=".games.guessit.lobbies.CreateJoinActivity"
             android:exported="false" >
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
         <activity
-            android:name=".games.guessit.LobbyListActivity"
+            android:name=".games.guessit.lobbies.LobbyListActivity"
             android:exported="false" >
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
         <activity
-            android:name=".games.guessit.WaitingRoomActivity"
+            android:name=".games.guessit.lobbies.WaitingRoomActivity"
+            android:exported="false" >
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
+        <activity
+            android:name=".games.guessit.lobbies.CreatePublicPrivateActivity"
             android:exported="false" >
             <meta-data
                 android:name="android.app.lib_name"

--- a/app/src/main/java/com/github/freeman/bootcamp/EditProfileActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/EditProfileActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -34,6 +35,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -248,7 +250,14 @@ fun TopAppbarEditProfile(context: Context = LocalContext.current) {
 
 // Dialog that edits any field given in argument
 @Composable
-fun EditDialog(text: MutableState<String>, setValue: String = SET_VALUE, enterValue: String = ENTER_VALUE, show: MutableState<Boolean>, updateData: (String) -> Unit) {
+fun EditDialog(
+    text: MutableState<String>,
+    setValue: String = SET_VALUE,
+    enterValue: String = ENTER_VALUE,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    show: MutableState<Boolean>,
+    updateData: (String) -> Unit
+) {
 
     val txtFieldError = remember { mutableStateOf("") }
     val txtField = remember { mutableStateOf(text.value) }
@@ -293,6 +302,7 @@ fun EditDialog(text: MutableState<String>, setValue: String = SET_VALUE, enterVa
                     Spacer(modifier = Modifier.height(20.dp))
 
                     TextField(
+                        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                         modifier = Modifier
                             .testTag("dialogTextField")
                             .fillMaxWidth()

--- a/app/src/main/java/com/github/freeman/bootcamp/EditProfileActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/EditProfileActivity.kt
@@ -248,7 +248,7 @@ fun TopAppbarEditProfile(context: Context = LocalContext.current) {
 
 // Dialog that edits any field given in argument
 @Composable
-private fun EditDialog(text: MutableState<String>, updateData: (String) -> Unit, show: MutableState<Boolean>) {
+fun EditDialog(text: MutableState<String>, setValue: String = SET_VALUE, enterValue: String = ENTER_VALUE, show: MutableState<Boolean>, updateData: (String) -> Unit) {
 
     val txtFieldError = remember { mutableStateOf("") }
     val txtField = remember { mutableStateOf(text.value) }
@@ -272,7 +272,7 @@ private fun EditDialog(text: MutableState<String>, updateData: (String) -> Unit,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = SET_VALUE,
+                            text = setValue,
                             style = TextStyle(
                                 fontSize = 24.sp,
                                 fontFamily = FontFamily.Default,
@@ -320,7 +320,7 @@ private fun EditDialog(text: MutableState<String>, updateData: (String) -> Unit,
                                     .height(20.dp)
                             )
                         },
-                        placeholder = { Text(text = ENTER_VALUE) },
+                        placeholder = { Text(text = enterValue) },
                         value = txtField.value,
                         onValueChange = {
                             txtField.value = it

--- a/app/src/main/java/com/github/freeman/bootcamp/MainMenuActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/MainMenuActivity.kt
@@ -23,10 +23,10 @@ import com.github.freeman.bootcamp.MainMenuActivity.Companion.PLAY
 import com.github.freeman.bootcamp.MainMenuActivity.Companion.SETTINGS
 import com.github.freeman.bootcamp.MainMenuActivity.Companion.VIDEO_CALL
 import com.github.freeman.bootcamp.MainMenuActivity.Companion.WORDLE
-import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity
 import com.github.freeman.bootcamp.games.guessit.chat.ChatActivity
 import com.github.freeman.bootcamp.games.guessit.drawing.DrawingActivity
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreateJoinActivity
 import com.github.freeman.bootcamp.games.wordle.WordleMenu
 import com.github.freeman.bootcamp.recorder.AudioRecordingActivity
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme

--- a/app/src/main/java/com/github/freeman/bootcamp/MainMenuActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/MainMenuActivity.kt
@@ -55,7 +55,7 @@ class MainMenuActivity : ComponentActivity() {
             // If no profile exists, sign in anonymously and creates a profile
             dbRef
                 .child(getString(R.string.profiles_path))
-                .child(userId!!)
+                .child(userId.toString())
                 .child(getString(R.string.username_path))
                 .get()
                 .addOnCompleteListener {

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameData.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameData.kt
@@ -20,6 +20,8 @@ data class Current(
 )
 
 data class Parameters(
+    val type: String,
+    val password: String,
     val category: String,
     val host_id: String,
     val nb_players: Int,

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameOptionsActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameOptionsActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.icons.Icons
@@ -22,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.github.freeman.bootcamp.R
@@ -38,7 +40,6 @@ import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.s
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selectedTopics
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selection
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_TYPE_TEXT
-import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities
@@ -62,7 +63,7 @@ class GameOptionsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val dbRef = Firebase.database.reference
-        val lobbyType = intent.getStringExtra(TYPE_TEXT).toString()
+        val lobbyType = intent.getStringExtra(getString(R.string.type_extra)).toString()
 
         setContent {
             BootcampComposeTheme {
@@ -365,6 +366,8 @@ private fun PasswordInput(password: MutableState<String>) {
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent
             ),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
+
         )
     }
 

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameOptionsActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameOptionsActivity.kt
@@ -37,6 +37,8 @@ import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.c
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selectedCategory
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selectedTopics
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selection
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_TYPE_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities
@@ -50,13 +52,17 @@ import com.google.firebase.database.ktx.getValue
 import com.google.firebase.ktx.Firebase
 import java.util.*
 
+/**
+ * Displays a screen where a player that wants to create a lobby will use in order
+ * to choose different options for the game
+ */
 class GameOptionsActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val dbRef = Firebase.database.reference
-        val lobbyType = intent.getStringExtra("type").toString()
+        val lobbyType = intent.getStringExtra(TYPE_TEXT).toString()
 
         setContent {
             BootcampComposeTheme {
@@ -391,7 +397,7 @@ fun GameOptionsScreen(dbRef: DatabaseReference, lobbyType: String) {
         )
         RoundsDisplay()
 
-        if (lobbyType == "private") {
+        if (lobbyType == PRIVATE_TYPE_TEXT) {
             PasswordInput(password)
         }
         NextButton(dbRef, lobbyType, password.value)

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameOptionsActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/GameOptionsActivity.kt
@@ -349,7 +349,9 @@ fun GameOptionsBackButton() {
 private fun PasswordInput(password: MutableState<String>) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(8.dp)
+        modifier = Modifier
+            .padding(8.dp)
+            .testTag("passwordInput")
     ) {
         TextField(
             value = password.value,
@@ -357,7 +359,7 @@ private fun PasswordInput(password: MutableState<String>) {
                 password.value = it
             },
             modifier = Modifier
-                .testTag("passwordInput"),
+                .testTag("passwordInputTextField"),
             placeholder = { Text(PASSWORD_PLACEHOLDER) },
             colors = TextFieldDefaults.textFieldColors(
                 focusedIndicatorColor = Color.Transparent,

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingActivity.kt
@@ -2,7 +2,6 @@ package com.github.freeman.bootcamp.games.guessit.drawing
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.provider.Settings.Global.getString
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.DrawableRes
@@ -20,8 +19,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.freeman.bootcamp.R
-import com.github.freeman.bootcamp.black
-import com.github.freeman.bootcamp.colorArray
 import com.github.freeman.bootcamp.games.guessit.TimerOverPopUp
 import com.github.freeman.bootcamp.games.guessit.TimerScreen
 import com.github.freeman.bootcamp.games.guessit.drawing.DrawingActivity.Companion.roundNb
@@ -33,9 +30,7 @@ import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.ValueEventListener
-import com.google.firebase.database.ktx.database
 import com.google.firebase.database.ktx.getValue
-import com.google.firebase.ktx.Firebase
 import io.ak1.drawbox.DrawBox
 import io.ak1.drawbox.DrawController
 import io.ak1.drawbox.rememberDrawController

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingColors.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingColors.kt
@@ -1,4 +1,4 @@
-package com.github.freeman.bootcamp
+package com.github.freeman.bootcamp.games.guessit.drawing
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreateJoinActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreateJoinActivity.kt
@@ -1,4 +1,4 @@
-package com.github.freeman.bootcamp.games.guessit
+package com.github.freeman.bootcamp.games.guessit.lobbies
 
 import android.app.Activity
 import android.content.Context
@@ -21,9 +21,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.freeman.bootcamp.R
-import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity.Companion.CREATE_GAME_BUTTON_TEXT
-import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity.Companion.JOINING_GAME_BUTTON_TEXT
-import com.github.freeman.bootcamp.games.guessit.CreateJoinActivity.Companion.TOPBAR_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreateJoinActivity.Companion.CREATE_GAME_BUTTON_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreateJoinActivity.Companion.JOINING_GAME_BUTTON_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreateJoinActivity.Companion.TOPBAR_TEXT
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 
 /**
@@ -110,7 +110,7 @@ fun CreateGameButton() {
     val context = LocalContext.current
     ElevatedButton(
         modifier = Modifier.testTag(context.getString(R.string.createjoin_creategame)),
-        onClick = { context.startActivity(Intent(context, GameOptionsActivity::class.java)) }
+        onClick = { context.startActivity(Intent(context, CreatePublicPrivateActivity::class.java)) }
     ) {
         Text(CREATE_GAME_BUTTON_TEXT)
     }

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
@@ -47,7 +47,7 @@ class CreatePublicPrivateActivity: ComponentActivity() {
 
 
 @Composable
-private fun TopAppbarPublicPrivate(context: Context = LocalContext.current) {
+fun TopAppbarPublicPrivate(context: Context = LocalContext.current) {
 
     TopAppBar(
         modifier = Modifier.testTag("topAppbarPublicPrivate"),
@@ -61,7 +61,9 @@ private fun TopAppbarPublicPrivate(context: Context = LocalContext.current) {
         backgroundColor = MaterialTheme.colors.background,
         elevation = 4.dp,
         navigationIcon = {
-            IconButton(onClick = {
+            IconButton(
+                modifier = Modifier.testTag("topAppbarPublicPrivateButton"),
+                onClick = {
                 val activity = (context as? Activity)
                 activity?.finish()
             }) {
@@ -75,7 +77,7 @@ private fun TopAppbarPublicPrivate(context: Context = LocalContext.current) {
 }
 
 @Composable
-private fun MainScreen() {
+fun MainScreen() {
     Column (
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
@@ -18,13 +18,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.github.freeman.bootcamp.R
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_BUTTON_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PUBLIC_BUTTON_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PUBLIC_TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TOPBAR_TEXT
-import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TYPE_TEXT
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 
 /**
@@ -47,7 +47,6 @@ class CreatePublicPrivateActivity: ComponentActivity() {
         const val TOPBAR_TEXT = "Create a lobby"
         const val PUBLIC_BUTTON_TEXT = "Public lobby"
         const val PRIVATE_BUTTON_TEXT = "Private lobby"
-        const val TYPE_TEXT = "type"
         const val PUBLIC_TYPE_TEXT = "public"
         const val PRIVATE_TYPE_TEXT = "private"
     }
@@ -108,7 +107,7 @@ private fun PublicLobbyButton() {
         onClick = {
             context.startActivity(
                 Intent(context, GameOptionsActivity::class.java)
-                    .putExtra(TYPE_TEXT, PUBLIC_TYPE_TEXT)
+                    .putExtra(context.getString(R.string.type_extra), PUBLIC_TYPE_TEXT)
             )
         }
     ) {
@@ -124,7 +123,7 @@ private fun PrivateLobbyButton() {
         onClick = {
             context.startActivity(
                 Intent(context, GameOptionsActivity::class.java)
-                    .putExtra(TYPE_TEXT, PRIVATE_TYPE_TEXT)
+                    .putExtra(context.getString(R.string.type_extra), PRIVATE_TYPE_TEXT)
             )
         }
     ) {

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
@@ -1,0 +1,122 @@
+package com.github.freeman.bootcamp.games.guessit.lobbies
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_BUTTON_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PUBLIC_BUTTON_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TOPBAR_TEXT
+import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
+
+class CreatePublicPrivateActivity: ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            BootcampComposeTheme {
+                TopAppbarPublicPrivate()
+
+                MainScreen()
+            }
+        }
+    }
+
+    companion object {
+        const val TOPBAR_TEXT = "Create a lobby"
+        const val PUBLIC_BUTTON_TEXT = "Public lobby"
+        const val PRIVATE_BUTTON_TEXT = "Private lobby"
+    }
+}
+
+
+
+@Composable
+private fun TopAppbarPublicPrivate(context: Context = LocalContext.current) {
+
+    TopAppBar(
+        modifier = Modifier.testTag("topAppbarPublicPrivate"),
+        title = {
+            Text(
+                text = TOPBAR_TEXT,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        backgroundColor = MaterialTheme.colors.background,
+        elevation = 4.dp,
+        navigationIcon = {
+            IconButton(onClick = {
+                val activity = (context as? Activity)
+                activity?.finish()
+            }) {
+                Icon(
+                    Icons.Filled.ArrowBack,
+                    contentDescription = "Go back",
+                )
+            }
+        }
+    )
+}
+
+@Composable
+private fun MainScreen() {
+    Column (
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("createPublicPrivateMainScreen"),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ){
+        PublicLobbyButton()
+        Spacer(modifier = Modifier.size(6.dp))
+        PrivateLobbyButton()
+    }
+}
+
+@Composable
+private fun PublicLobbyButton() {
+    val context = LocalContext.current
+    ElevatedButton(
+        modifier = Modifier.testTag("publicLobbyButton"),
+        onClick = {
+            context.startActivity(
+                Intent(context, GameOptionsActivity::class.java)
+                    .putExtra("type", "public")
+            )
+        }
+    ) {
+        Text(PUBLIC_BUTTON_TEXT)
+    }
+}
+
+@Composable
+private fun PrivateLobbyButton() {
+    val context = LocalContext.current
+    ElevatedButton(
+        modifier = Modifier.testTag("privateLobbyButton"),
+        onClick = {
+            context.startActivity(
+                Intent(context, GameOptionsActivity::class.java)
+                    .putExtra("type", "private")
+            )
+        }
+    ) {
+        Text(PRIVATE_BUTTON_TEXT)
+    }
+}

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/CreatePublicPrivateActivity.kt
@@ -20,10 +20,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_BUTTON_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PUBLIC_BUTTON_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PUBLIC_TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TOPBAR_TEXT
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.TYPE_TEXT
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 
+/**
+ * Shows a screen where you can either choose to create a public or a private lobby
+ */
 class CreatePublicPrivateActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,6 +47,9 @@ class CreatePublicPrivateActivity: ComponentActivity() {
         const val TOPBAR_TEXT = "Create a lobby"
         const val PUBLIC_BUTTON_TEXT = "Public lobby"
         const val PRIVATE_BUTTON_TEXT = "Private lobby"
+        const val TYPE_TEXT = "type"
+        const val PUBLIC_TYPE_TEXT = "public"
+        const val PRIVATE_TYPE_TEXT = "private"
     }
 }
 
@@ -99,7 +108,7 @@ private fun PublicLobbyButton() {
         onClick = {
             context.startActivity(
                 Intent(context, GameOptionsActivity::class.java)
-                    .putExtra("type", "public")
+                    .putExtra(TYPE_TEXT, PUBLIC_TYPE_TEXT)
             )
         }
     ) {
@@ -115,7 +124,7 @@ private fun PrivateLobbyButton() {
         onClick = {
             context.startActivity(
                 Intent(context, GameOptionsActivity::class.java)
-                    .putExtra("type", "private")
+                    .putExtra(TYPE_TEXT, PRIVATE_TYPE_TEXT)
             )
         }
     ) {

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/LobbyListActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/LobbyListActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -82,7 +83,13 @@ class LobbyListActivity: ComponentActivity() {
                     if (enterPassword.value) {
                         val context = LocalContext.current
                         val userId = Firebase.auth.uid
-                        EditDialog(password, ENTER_PASSWORD_TEXT, PASSWORD_TEXT, enterPassword) {
+                        EditDialog(
+                            text = password,
+                            setValue = ENTER_PASSWORD_TEXT,
+                            enterValue = PASSWORD_TEXT,
+                            show = enterPassword,
+                            keyboardType = KeyboardType.NumberPassword
+                        ) {
                             if (lobby.value.password == it) {
                                 joinLobby(context, dbRef.child(context.getString(R.string.games_path)), userId.toString(), lobby.value)
                             } else {

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/LobbyListActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/LobbyListActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.freeman.bootcamp.EditDialog
 import com.github.freeman.bootcamp.R
+import com.github.freeman.bootcamp.games.guessit.lobbies.CreatePublicPrivateActivity.Companion.PRIVATE_TYPE_TEXT
 import com.github.freeman.bootcamp.games.guessit.lobbies.LobbyListActivity.Companion.DEFAULT_ID
 import com.github.freeman.bootcamp.games.guessit.lobbies.LobbyListActivity.Companion.DEFAULT_LOBBY
 import com.github.freeman.bootcamp.games.guessit.lobbies.LobbyListActivity.Companion.DEFAULT_NB_PLAYER
@@ -77,6 +78,7 @@ class LobbyListActivity: ComponentActivity() {
                         }
                     }
 
+                    // Shows the dialog when a private lobby is clicked
                     if (enterPassword.value) {
                         val context = LocalContext.current
                         val userId = Firebase.auth.uid
@@ -196,13 +198,13 @@ fun ListItem(
             Column (
                 horizontalAlignment = Alignment.End
             ) {
-                if(lobby.type == "private") {
+                if(lobby.type == PRIVATE_TYPE_TEXT) {
                     Icon(
                         Icons.Filled.Lock,
-                        contentDescription = "private"
+                        contentDescription = PRIVATE_TYPE_TEXT
                     )
                 } else {
-                    // This empty text is to place the players text on the bottom
+                    // This empty text is to place the "players" text on the bottom
                     Text(
                         text = "",
                         fontWeight = FontWeight.Normal,
@@ -282,16 +284,12 @@ fun LobbyList(database: DatabaseReference, enterPassword: MutableState<Boolean>,
                     lobby = lobby,
                     backgroundColor = Color.White,
                     onItemClick = {
-                        if (lobby.type == "private") {
+                        if (lobby.type == PRIVATE_TYPE_TEXT) {
                             defaultLobby.value = lobby
                             enterPassword.value = true
                         } else {
                             joinLobby(context, dbRef, userId.toString(), lobby)
                         }
-
-
-                        // joins a lobby
-//                        joinLobby(context, dbRef, userId.toString(), lobby)
                     },
                 )
             }
@@ -299,6 +297,14 @@ fun LobbyList(database: DatabaseReference, enterPassword: MutableState<Boolean>,
     }
 }
 
+/**
+ * Makes a player join a lobby
+ *
+ * @param context current context of the app
+ * @param dbRef database reference
+ * @param userId firebase auth id of the user
+ * @param lobby the lobby to join
+ */
 fun joinLobby(context: Context, dbRef: DatabaseReference, userId: String, lobby: Lobby) {
         dbRef
             .child(lobby.id)

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/WaitingRoomActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/WaitingRoomActivity.kt
@@ -1,4 +1,4 @@
-package com.github.freeman.bootcamp.games.guessit
+package com.github.freeman.bootcamp.games.guessit.lobbies
 
 import android.app.Activity
 import android.content.Context
@@ -38,11 +38,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.github.freeman.bootcamp.R
-import com.github.freeman.bootcamp.games.guessit.WaitingRoomActivity.Companion.CATEGORY_INFO
-import com.github.freeman.bootcamp.games.guessit.WaitingRoomActivity.Companion.KICKED
-import com.github.freeman.bootcamp.games.guessit.WaitingRoomActivity.Companion.NB_ROUNDS_INFO
-import com.github.freeman.bootcamp.games.guessit.WaitingRoomActivity.Companion.START_GAME
-import com.github.freeman.bootcamp.games.guessit.WaitingRoomActivity.Companion.TOPBAR_TEXT
+import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity
+import com.github.freeman.bootcamp.games.guessit.TopicSelectionActivity
+import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity.Companion.CATEGORY_INFO
+import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity.Companion.KICKED
+import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity.Companion.NB_ROUNDS_INFO
+import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity.Companion.START_GAME
+import com.github.freeman.bootcamp.games.guessit.lobbies.WaitingRoomActivity.Companion.TOPBAR_TEXT
 import com.github.freeman.bootcamp.games.guessit.guessing.GuessingActivity
 import com.github.freeman.bootcamp.ui.theme.BootcampComposeTheme
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities.databaseGet
@@ -67,6 +69,7 @@ class WaitingRoomActivity: ComponentActivity() {
         val userId = Firebase.auth.uid
 
         val gameId = intent.getStringExtra(getString(R.string.gameId_extra)).toString()
+
         val allTopics = ArrayList<String>()
 
         val database = Firebase.database.reference

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
 
     <!-- Strings used for extra between activities -->
     <string name="gameId_extra">gameId</string>
+    <string name="type_extra">type</string>
+    <string name="password_extra">password</string>
     <string name="gameId_testing">testing</string>
 
     <!-- current_state states -->

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,8 +1,3 @@
-14:59:23.480 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-14:59:23.949 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
-14:59:58.363 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it successfully activated FBKV (SurveyIdle(0)) wait: 229ms, init: 0ms
-15:04:37.405 [FirebaseWorkerPool-1-3] WARN com.firebase.core.persistence.backend.dummy.EmulatorMetadataPersistence - Multiple projectIds are not recommended in single project mode. Requested 
-namespace sdp-guess-it-default-rtdb, but the emulator is configured for sdp-guess-it. To 
-opt-out of single project mode add/set the single_project_mode: false property in 
-the firebase.json emulators config. 
-15:04:37.640 [NamespaceSystem-akka.actor.default-dispatcher-10] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 48ms, init: 0ms
+17:47:00.975 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+17:47:01.183 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+17:53:39.682 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 364ms, init: 0ms

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,3 +1,3 @@
-17:47:00.975 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-17:47:01.183 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
-17:53:39.682 [NamespaceSystem-akka.actor.default-dispatcher-6] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 364ms, init: 0ms
+18:20:47.516 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+18:20:47.711 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+18:21:26.015 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO com.firebase.core.namespace.NamespaceActor - sdp-guess-it-default-rtdb successfully activated FBKV (SurveyIdle(0)) wait: 255ms, init: 0ms


### PR DESCRIPTION
This adds a way to create a private lobby and join it with a password.

When pressing the "create game" button, the player is asked to choose between creating a private game or a public game. A public game behaves as previously. A private game allows you to enter a password in the game option activity.

When joining a game a player can differentiate a private lobby and a public one by noticing a lock icon next to private ones. if a player decides to join a private lobby a dialog appears asking him to enter a password. If he enters it correctly he enters the waiting room but if he fails he returns to the lobby list.