### PR TITLE
Added an alert before account deletion

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -283,6 +283,20 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="1087390385">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="39V4C19703010730" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="HUAWEI&#10; POT-LX1" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1113946193">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -191,6 +191,20 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-244793646">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="39V4C19703010730" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="HUAWEI&#10; POT-LX1" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-30102969">
           <value>
             <AndroidTestResultsTableState>

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
@@ -88,6 +88,15 @@ class FirebaseAuthActivityTest {
         composeRule.onNodeWithTag("deletionAlertDialog").assertIsDisplayed()
         composeRule.onNodeWithTag("deleteButton").assertIsDisplayed()
         composeRule.onNodeWithTag("cancelButton").assertIsDisplayed()
+        composeRule.onNodeWithTag("deletionAlertTitle").assertIsDisplayed()
+        composeRule.onNodeWithTag("deletionAlertText").assertIsDisplayed()
+    }
+
+    @Test
+    fun deletionWarningContainsCorrectText() {
+        initDeletionWarning()
+        composeRule.onNodeWithTag("deletionAlertTitle").assertTextContains(FirebaseAuthActivity.DELETION_WARNING_TITLE)
+        composeRule.onNodeWithTag("deletionAlertText").assertTextContains(FirebaseAuthActivity.DELETION_WARNING_TEXT)
     }
 
     @Test
@@ -100,8 +109,8 @@ class FirebaseAuthActivityTest {
     @Test
     fun cancelDeletionButtonContainsCorrectText() {
         initDeletionWarning()
-        composeRule.onNodeWithTag("cancelButton").assertHasClickAction()
         composeRule.onNodeWithTag("cancelButton").assertTextContains(CANCEL_BUTTON)
+        composeRule.onNodeWithTag("cancelButton").assertHasClickAction()
     }
 
 }

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivityTest.kt
@@ -56,8 +56,8 @@ class FirebaseAuthActivityTest {
         )
         val googleText = device.findObject(UiSelector().textContains(""))
         assert(googleText.exists())
-
-
     }
+
+
 
 }

--- a/app/src/main/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivity.kt
@@ -250,6 +250,7 @@ fun WarningDeletion(signInInfo: MutableState<String>, currentUser: MutableState<
     val context = LocalContext.current
 
     AlertDialog(
+        modifier = Modifier.testTag("deletionAlertDialog"),
         title = {
             Text(
                 text = DELETION_WARNING_TITLE,

--- a/app/src/main/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/auth/FirebaseAuthActivity.kt
@@ -254,6 +254,7 @@ fun WarningDeletion(signInInfo: MutableState<String>, currentUser: MutableState<
         title = {
             Text(
                 text = DELETION_WARNING_TITLE,
+                modifier = Modifier.testTag("deletionAlertTitle"),
                 style = TextStyle(
                     fontSize = 24.sp,
                     fontWeight = FontWeight.Bold
@@ -261,7 +262,10 @@ fun WarningDeletion(signInInfo: MutableState<String>, currentUser: MutableState<
             )
         },
         text = {
-            Text(DELETION_WARNING_TEXT)
+            Text(
+                text = DELETION_WARNING_TEXT,
+                modifier = Modifier.testTag("deletionAlertText")
+            )
         },
         onDismissRequest = {
             show.value = false },


### PR DESCRIPTION
To prevent mis-clicking for this no-return action, I added a warning to be sure it is what the user really want (i.e. delete his/her account with all data in it).  

You can access it from the main meny through "Settings>Manage Account>Delete 'Guess It!' account" (You need to be authenticated via Google)