### PR TITLE
Fixed topic selection and timer

### DIFF
--- a/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/GameOptionsActivityTest.kt
@@ -12,7 +12,6 @@ import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.N
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.NEXT
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.ROUNDS_SELECTION
 import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.categories
-import com.github.freeman.bootcamp.games.guessit.GameOptionsActivity.Companion.selectedTopics
 import com.github.freeman.bootcamp.games.guessit.GameOptionsScreen
 import com.github.freeman.bootcamp.games.guessit.lobbies.CreateGameButton
 import com.github.freeman.bootcamp.games.guessit.lobbies.JoinGameButton
@@ -116,7 +115,6 @@ class GameOptionsActivityTest {
     @Test
     fun animalTopicsFetchedUponClick() {
         setGameOptionsScreen()
-        assertTrue(selectedTopics.isEmpty())
         composeRule.onNodeWithText(categories[0]).performClick()
 
         // This step is necessary for the app to have enough time to fill the topics list

--- a/app/src/androidTest/java/com/github/freeman/bootcamp/GuessingTest.kt
+++ b/app/src/androidTest/java/com/github/freeman/bootcamp/GuessingTest.kt
@@ -54,7 +54,7 @@ class GuessingTest {
                 .child(context.getString(R.string.test_game_id))
 
             BootcampComposeTheme {
-                GuessingScreen(database, context = context,guessGameId, storageGamRef)
+                GuessingScreen(database, context = context, storageGamRef)
             }
         }
     }

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/TopicSelectionActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/TopicSelectionActivity.kt
@@ -46,10 +46,6 @@ class TopicSelectionActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val gameId = intent.getStringExtra(getString(R.string.gameId_extra)).toString()
         dbref = getGameDBRef(this, gameId)
-        topics.clear()
-        for (i in 0 until NB_TOPICS) {
-            topics.add(intent.getStringExtra("topic$i").toString())
-        }
 
         // inform database that a player is in the topic selection phase
         dbref.child(getString(R.string.current_state_path))
@@ -167,6 +163,7 @@ fun TopicSelectionScreen(dbref: DatabaseReference, gameId: String) {
     val topic1 = remember { mutableStateOf(topics[1]) }
     val topic2 = remember { mutableStateOf(topics[2]) }
     val topicList = listOf(topic0, topic1, topic2)
+    refreshTopics(context, dbref, topicList)
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/drawing/DrawingActivity.kt
@@ -170,35 +170,26 @@ fun DrawingScreen(
             if (timer == context.getString(R.string.timer_over)) {
                 TimerOverPopUp()
             } else {
-                Row() {
-                    // Video calls deactivated for now because of camera conflict
-//                    BootcampComposeTheme { // Video conversation zone
-//                        VideoScreen2(
-//                            roomName = gameId,
-//                            testing = false
-//                        )
-//                    }
-                    // Drawing zone
-                    DrawBox(
-                        drawController = drawController,
-                        backgroundColor = Color.White,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .weight(1f, fill = false),
-                        bitmapCallback = { imageBitmap, _ -> // Tells the drawController what to do when drawController.saveBitmap() is called
-                            imageBitmap?.let {
-                                dbref.child(context.getString(R.string.topics_path))
-                                    .child(roundNb.toString())
-                                    .child(turnNb.toString())
-                                    .child(context.getString(R.string.drawing_path))
-                                    .setValue(BitmapHandler.bitmapToString(it.asAndroidBitmap()))
-                            }
+                // Drawing zone
+                DrawBox(
+                    drawController = drawController,
+                    backgroundColor = Color.White,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .weight(1f, fill = false),
+                    bitmapCallback = { imageBitmap, _ -> // Tells the drawController what to do when drawController.saveBitmap() is called
+                        imageBitmap?.let {
+                            dbref.child(context.getString(R.string.topics_path))
+                                .child(roundNb.toString())
+                                .child(turnNb.toString())
+                                .child(context.getString(R.string.drawing_path))
+                                .setValue(BitmapHandler.bitmapToString(it.asAndroidBitmap()))
                         }
-                    ) { undoCount, redoCount ->
-                        colorBarVisibility.value = false
-                        undoVisibility.value = undoCount != 0
-                        redoVisibility.value = redoCount != 0
                     }
+                ) { undoCount, redoCount ->
+                    colorBarVisibility.value = false
+                    undoVisibility.value = undoCount != 0
+                    redoVisibility.value = redoCount != 0
                 }
             }
         }

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/guessing/GuessingActivity.kt
@@ -5,7 +5,6 @@ package com.github.freeman.bootcamp.games.guessit.guessing
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
-import android.content.pm.PackageManager.FEATURE_CAMERA_FRONT
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
@@ -24,7 +23,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asAndroidBitmap
@@ -57,7 +55,6 @@ import com.github.freeman.bootcamp.utilities.BitmapHandler
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities
 import com.github.freeman.bootcamp.utilities.firebase.FirebaseUtilities.getGameDBRef
 import com.github.freeman.bootcamp.utilities.rememberImeState
-import com.github.freeman.bootcamp.videocall.VideoScreen2
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -89,7 +86,7 @@ class GuessingActivity : ComponentActivity() {
 
         setContent {
             BootcampComposeTheme {
-                GuessingScreen(dbrefGame, this, gameId, storageGameRef)
+                GuessingScreen(dbrefGame, this, storageGameRef)
             }
         }
     }
@@ -144,8 +141,7 @@ fun GuessItem(guess: Guess, answer: String, dbrefGame: DatabaseReference, artist
                     // If the artist hasn't yet received points for this drawing, grant them
                     if (nbGuesses.toInt() == 0) {
                         FirebaseUtilities.databaseGetLong(dbArtistScoreRef)
-                            .thenAccept {
-                                val artistsPoints = it
+                            .thenAccept { artistsPoints ->
                                 dbArtistScoreRef.setValue(artistsPoints + 1)
                             }
                     }
@@ -158,10 +154,9 @@ fun GuessItem(guess: Guess, answer: String, dbrefGame: DatabaseReference, artist
 
                     // Give the points to the player who guessed correctly
                     FirebaseUtilities.databaseGetLong(dbGuesserScoreRef)
-                        .thenAccept {
+                        .thenAccept { score ->
                             // Increase current player's points
                             if (!pointsReceived) {
-                                val score = it
                                 dbGuesserScoreRef.setValue(score + 1)
                                 pointsReceived = true
                             }
@@ -306,9 +301,8 @@ fun GuessingBar(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun GuessingScreen(dbrefGame: DatabaseReference, context: Context,gameId: String, storageGameRef: StorageReference) {
+fun GuessingScreen(dbrefGame: DatabaseReference, context: Context, storageGameRef: StorageReference) {
     val imeState = rememberImeState()
     val scrollState = rememberScrollState()
 
@@ -332,7 +326,7 @@ fun GuessingScreen(dbrefGame: DatabaseReference, context: Context,gameId: String
             }
         }
         override fun onCancelled(error: DatabaseError) {
-            TODO("Not yet implemented")
+            // do nothing
         }
     })
 
@@ -478,25 +472,17 @@ fun GuessingScreen(dbrefGame: DatabaseReference, context: Context,gameId: String
                         color = Color.DarkGray
                     )
                 } else {
-                    Row() {
-                        // Video calls deactivated for now because of camera conflict
-//                        BootcampComposeTheme { // Video conversation zone
-//                            VideoScreen2(
-//                                roomName = gameId,
-//                                testing = false
-//                            )
-//                        }
-                        Image(
-                            bitmap = displayedBitmap,
-                            contentDescription = "drawn image",
-                            modifier = Modifier
-                                .fillMaxWidth()
-                              //  .align(Alignment.Center)
-                        )
-                    }
+                    Image(
+                        bitmap = displayedBitmap,
+                        contentDescription = "drawn image",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.Center)
+                    )
                 }
 
-                if (timer != context.getString(R.string.timer_unused)) {
+                if (timer != context.getString(R.string.timer_unused)
+                    && timer != context.getString(R.string.timer_over)) {
                     val dbRefTimer = dbrefGame.child(context.getString(R.string.current_timer_path))
                     TimerScreen(dbRefTimer, 60L, fontSize = 30.sp, textColor = Color.DarkGray)
                 }

--- a/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/WaitingRoomActivity.kt
+++ b/app/src/main/java/com/github/freeman/bootcamp/games/guessit/lobbies/WaitingRoomActivity.kt
@@ -59,7 +59,7 @@ import com.google.firebase.storage.ktx.storage
 /**
  *  A screen where players wait until the host starts the game.
  *  When the activity is created, it retrieves the user's ID and the game ID from the intent that
- *  started it. It also initializes a list of all topics that will be used in the game.
+ *  started it.
  *  It displays a top app bar with information about the room, a list of players currently in the
  *  room, and a "Start" button. The activity listens to changes in the game state and updates the
  *  UI accordingly. When the game state changes to "play game", the activity starts the appropriate
@@ -75,17 +75,10 @@ class WaitingRoomActivity: ComponentActivity() {
 
         val gameId = intent.getStringExtra(getString(R.string.gameId_extra)).toString()
 
-        val allTopics = ArrayList<String>()
-
         val database = Firebase.database.reference
         val dbRef = getGameDBRef(this, gameId)
 
         val storage = Firebase.storage.reference
-
-
-        for (i in 0 until GameOptionsActivity.NB_TOPICS) {
-            allTopics.add(intent.getStringExtra("topic$i").toString())
-        }
 
         setContent {
             val context = LocalContext.current
@@ -108,9 +101,6 @@ class WaitingRoomActivity: ComponentActivity() {
                             val intent = Intent(context, GameManagerService::class.java)
                             intent.apply {
                                 putExtra(getString(R.string.gameId_extra), gameId)
-                                for (i in allTopics.indices) {
-                                    putExtra("topic$i", allTopics[i])
-                                }
                             }
                             context.startService(intent)
                         } else if (gameState == getString(R.string.state_lobbyclosed)) {


### PR DESCRIPTION
- The topic selection activity now always displays topics, even between turns.
- The timer on the guessing activity waits for the drawer to pick a word before starting.
- Otherwise, small refactorings and cleanups.